### PR TITLE
Add docker-compose.yml for containerized deployment

### DIFF
--- a/express/.env.example
+++ b/express/.env.example
@@ -1,0 +1,16 @@
+# WISPr Configuration
+
+# API key for authentication
+API_KEY=your-api-key-here
+
+# HTTP port (default: 8080)
+HTTP_PORT=8080
+
+# HTTPS port (default: 8443)
+HTTPS_PORT=8443
+
+# TLS certificate path
+TLS_CERT=./certs/server.crt
+
+# TLS private key path
+TLS_KEY=./certs/server.key

--- a/express/.gitignore
+++ b/express/.gitignore
@@ -1,0 +1,28 @@
+# Dependencies
+node_modules/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Certificates (may contain sensitive keys)
+certs/
+*.pem
+*.key
+*.crt

--- a/express/docker-compose.yml
+++ b/express/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  wispr:
+    build: .
+    ports:
+      - "9080:8080"
+      - "9443:8443"
+    env_file:
+      - .env
+    volumes:
+      - ./public:/usr/src/app/public
+      - ./views:/usr/src/app/views
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add docker-compose.yml for running WISPr in Docker
- Maps host ports 9080/9443 to container ports 8080/8443 to avoid conflicts with Keycloak
- Mounts public/ and views/ directories for live reloading during development

## Test plan
- [ ] Run `docker compose up --build`
- [ ] Verify http://localhost:9080 loads the login page
- [ ] Verify HTTPS works on https://localhost:9443

🤖 Generated with [Claude Code](https://claude.com/claude-code)